### PR TITLE
Fix error when only one input mention is given

### DIFF
--- a/allennlp/models/coreference_resolution/coref.py
+++ b/allennlp/models/coreference_resolution/coref.py
@@ -173,7 +173,8 @@ class CoreferenceResolver(Model):
         text_mask = util.get_text_field_mask(text).float()
 
         # Shape: (batch_size, num_spans)
-        span_mask = (spans[:, :, 0] >= 0).squeeze(-1).float()
+        span_mask = (spans[:, :, 0] >= 0).squeeze(-1).reshape((spans.shape[0], spans.shape[1])) \
+            .float()
         # SpanFields return -1 when they are used as padding. As we do
         # some comparisons based on span widths when we attend over the
         # span representations that we generate from these indices, we

--- a/allennlp/models/coreference_resolution/coref.py
+++ b/allennlp/models/coreference_resolution/coref.py
@@ -173,6 +173,9 @@ class CoreferenceResolver(Model):
         text_mask = util.get_text_field_mask(text).float()
 
         # Shape: (batch_size, num_spans)
+        # In order to get the correct shape, we collapse the last dimension (it should only be one
+        # index long). We then reshape it to make sure the shape is correct in edge cases (namely
+        # when there is exactly one input mention).
         span_mask = (spans[:, :, 0] >= 0).squeeze(-1).reshape((spans.shape[0], spans.shape[1])) \
             .float()
         # SpanFields return -1 when they are used as padding. As we do


### PR DESCRIPTION
Previously, if there were only one input mention, there would be an error when the mention pruner was called. This fixes that bug.